### PR TITLE
Fix type mismatch in EXPECT_EQ comparisons

### DIFF
--- a/tests/DocumentTest.cpp
+++ b/tests/DocumentTest.cpp
@@ -8,7 +8,7 @@
  * Credit to Sando Dargo's Blog on writing Unit tests on non-code files.
  * source:
  * https://www.sandordargo.com/blog/2024/02/21/cpp-tests-with-resources#copy-the-resources-to-the-build-file
- * 
+ *
  * Aside from that Google Gemini also helped in writing trivial tasks.
  */
 
@@ -43,14 +43,14 @@ TEST(DocumentTest, ConstructorSyntaxHighlight)
 {
   std::filesystem::path dirPath = std::filesystem::path(__FILE__).remove_filename();
   std::filesystem::path filePath = dirPath /= "DocumentTestFiles/cpp-sample.cpp";
-    
+
   Document doc(filePath);
   EXPECT_EQ(doc.GetRowsLength(), 5);
-  
+
   Row r1 = doc.GetRows()[0];
   EXPECT_EQ(r1.getHighlights().size(), 1);
   EXPECT_EQ(r1.getHighlights()[0].h_type, highlight_type::String);
-  EXPECT_EQ(r1.getHighlights()[0].h_idx, std::make_pair(9, 19));
+  EXPECT_EQ(r1.getHighlights()[0].h_idx, std::make_pair(9u, 19u));
 
   Row r2 = doc.GetRows()[1];
   EXPECT_EQ(r2.getHighlights().size(), 0);
@@ -58,22 +58,22 @@ TEST(DocumentTest, ConstructorSyntaxHighlight)
   Row r3 = doc.GetRows()[2];
   EXPECT_EQ(r3.getHighlights().size(), 2);
   EXPECT_EQ(r3.getHighlights()[0].h_type, highlight_type::Keyword);
-  EXPECT_EQ(r3.getHighlights()[0].h_idx, std::make_pair(0, 3));
+  EXPECT_EQ(r3.getHighlights()[0].h_idx, std::make_pair(0u, 3u));
   EXPECT_EQ(r3.getHighlights()[1].h_type, highlight_type::Identifier);
-  EXPECT_EQ(r3.getHighlights()[1].h_idx, std::make_pair(4, 8));
+  EXPECT_EQ(r3.getHighlights()[1].h_idx, std::make_pair(4u, 8u));
 
   Row r4 = doc.GetRows()[3];
   EXPECT_EQ(r4.getHighlights().size(), 5);
   EXPECT_EQ(r4.getHighlights()[0].h_type, highlight_type::Keyword);
-  EXPECT_EQ(r4.getHighlights()[0].h_idx, std::make_pair(1, 4));
+  EXPECT_EQ(r4.getHighlights()[0].h_idx, std::make_pair(1u, 4u));
   EXPECT_EQ(r4.getHighlights()[1].h_type, highlight_type::Identifier);
-  EXPECT_EQ(r4.getHighlights()[1].h_idx, std::make_pair(6, 10));
+  EXPECT_EQ(r4.getHighlights()[1].h_idx, std::make_pair(6u, 10u));
   EXPECT_EQ(r4.getHighlights()[2].h_type, highlight_type::String);
-  EXPECT_EQ(r4.getHighlights()[2].h_idx, std::make_pair(14, 27));
+  EXPECT_EQ(r4.getHighlights()[2].h_idx, std::make_pair(14u, 27u));
   EXPECT_EQ(r4.getHighlights()[3].h_type, highlight_type::Keyword);
-  EXPECT_EQ(r4.getHighlights()[3].h_idx, std::make_pair(31, 34));
+  EXPECT_EQ(r4.getHighlights()[3].h_idx, std::make_pair(31u, 34u));
   EXPECT_EQ(r4.getHighlights()[4].h_type, highlight_type::Identifier);
-  EXPECT_EQ(r4.getHighlights()[4].h_idx, std::make_pair(36, 40));
+  EXPECT_EQ(r4.getHighlights()[4].h_idx, std::make_pair(36u, 40u));
 
   Row r5 = doc.GetRows()[4];
   EXPECT_EQ(r5.getHighlights().size(), 0);
@@ -83,17 +83,17 @@ TEST(DocumentTest, InsertSyntaxHighlight)
 {
   std::filesystem::path dirPath = std::filesystem::path(__FILE__).remove_filename();
   std::filesystem::path filePath = dirPath /= "DocumentTestFiles/cpp-sample.cpp";
-    
+
   Document doc(filePath);
   EXPECT_EQ(doc.GetRowsLength(), 5);
 
   doc.Insert(26, 3, '!');
   EXPECT_EQ(doc.GetRows()[3].getText(), "\tstd::cout << \"Hello World!\" << std::endl;");
-  
+
   Row r1 = doc.GetRows()[0];
   EXPECT_EQ(r1.getHighlights().size(), 1);
   EXPECT_EQ(r1.getHighlights()[0].h_type, highlight_type::String);
-  EXPECT_EQ(r1.getHighlights()[0].h_idx, std::make_pair(9, 19));
+  EXPECT_EQ(r1.getHighlights()[0].h_idx, std::make_pair(9u, 19u));
 
   Row r2 = doc.GetRows()[1];
   EXPECT_EQ(r2.getHighlights().size(), 0);
@@ -101,22 +101,22 @@ TEST(DocumentTest, InsertSyntaxHighlight)
   Row r3 = doc.GetRows()[2];
   EXPECT_EQ(r3.getHighlights().size(), 2);
   EXPECT_EQ(r3.getHighlights()[0].h_type, highlight_type::Keyword);
-  EXPECT_EQ(r3.getHighlights()[0].h_idx, std::make_pair(0, 3));
+  EXPECT_EQ(r3.getHighlights()[0].h_idx, std::make_pair(0u, 3u));
   EXPECT_EQ(r3.getHighlights()[1].h_type, highlight_type::Identifier);
-  EXPECT_EQ(r3.getHighlights()[1].h_idx, std::make_pair(4, 8));
+  EXPECT_EQ(r3.getHighlights()[1].h_idx, std::make_pair(4u, 8u));
 
   Row r4 = doc.GetRows()[3];
   EXPECT_EQ(r4.getHighlights().size(), 5);
   EXPECT_EQ(r4.getHighlights()[0].h_type, highlight_type::Keyword);
-  EXPECT_EQ(r4.getHighlights()[0].h_idx, std::make_pair(1, 4));
+  EXPECT_EQ(r4.getHighlights()[0].h_idx, std::make_pair(1u, 4u));
   EXPECT_EQ(r4.getHighlights()[1].h_type, highlight_type::Identifier);
-  EXPECT_EQ(r4.getHighlights()[1].h_idx, std::make_pair(6, 10));
+  EXPECT_EQ(r4.getHighlights()[1].h_idx, std::make_pair(6u, 10u));
   EXPECT_EQ(r4.getHighlights()[2].h_type, highlight_type::String);
-  EXPECT_EQ(r4.getHighlights()[2].h_idx, std::make_pair(14, 28));
+  EXPECT_EQ(r4.getHighlights()[2].h_idx, std::make_pair(14u, 28u));
   EXPECT_EQ(r4.getHighlights()[3].h_type, highlight_type::Keyword);
-  EXPECT_EQ(r4.getHighlights()[3].h_idx, std::make_pair(32, 35));
+  EXPECT_EQ(r4.getHighlights()[3].h_idx, std::make_pair(32u, 35u));
   EXPECT_EQ(r4.getHighlights()[4].h_type, highlight_type::Identifier);
-  EXPECT_EQ(r4.getHighlights()[4].h_idx, std::make_pair(37, 41));
+  EXPECT_EQ(r4.getHighlights()[4].h_idx, std::make_pair(37u, 41u));
 
   Row r5 = doc.GetRows()[4];
   EXPECT_EQ(r5.getHighlights().size(), 0);
@@ -126,17 +126,17 @@ TEST(DocumentTest, DeleteSimpleSyntax)
 {
   std::filesystem::path dirPath = std::filesystem::path(__FILE__).remove_filename();
   std::filesystem::path filePath = dirPath /= "DocumentTestFiles/cpp-sample.cpp";
-    
+
   Document doc(filePath);
   EXPECT_EQ(doc.GetRowsLength(), 5);
 
   doc.Delete(3, 2);
   EXPECT_EQ(doc.GetRows()[2].getText(), "intmain() {");
-  
+
   Row r1 = doc.GetRows()[0];
   EXPECT_EQ(r1.getHighlights().size(), 1);
   EXPECT_EQ(r1.getHighlights()[0].h_type, highlight_type::String);
-  EXPECT_EQ(r1.getHighlights()[0].h_idx, std::make_pair(9, 19));
+  EXPECT_EQ(r1.getHighlights()[0].h_idx, std::make_pair(9u, 19u));
 
   Row r2 = doc.GetRows()[1];
   EXPECT_EQ(r2.getHighlights().size(), 0);
@@ -144,20 +144,20 @@ TEST(DocumentTest, DeleteSimpleSyntax)
   Row r3 = doc.GetRows()[2];
   EXPECT_EQ(r3.getHighlights().size(), 1);
   EXPECT_EQ(r3.getHighlights()[0].h_type, highlight_type::Identifier);
-  EXPECT_EQ(r3.getHighlights()[0].h_idx, std::make_pair(0, 7));
+  EXPECT_EQ(r3.getHighlights()[0].h_idx, std::make_pair(0u, 7u));
 
   Row r4 = doc.GetRows()[3];
   EXPECT_EQ(r4.getHighlights().size(), 5);
   EXPECT_EQ(r4.getHighlights()[0].h_type, highlight_type::Keyword);
-  EXPECT_EQ(r4.getHighlights()[0].h_idx, std::make_pair(1, 4));
+  EXPECT_EQ(r4.getHighlights()[0].h_idx, std::make_pair(1u, 4u));
   EXPECT_EQ(r4.getHighlights()[1].h_type, highlight_type::Identifier);
-  EXPECT_EQ(r4.getHighlights()[1].h_idx, std::make_pair(6, 10));
+  EXPECT_EQ(r4.getHighlights()[1].h_idx, std::make_pair(6u, 10u));
   EXPECT_EQ(r4.getHighlights()[2].h_type, highlight_type::String);
-  EXPECT_EQ(r4.getHighlights()[2].h_idx, std::make_pair(14, 27));
+  EXPECT_EQ(r4.getHighlights()[2].h_idx, std::make_pair(14u, 27u));
   EXPECT_EQ(r4.getHighlights()[3].h_type, highlight_type::Keyword);
-  EXPECT_EQ(r4.getHighlights()[3].h_idx, std::make_pair(31, 34));
+  EXPECT_EQ(r4.getHighlights()[3].h_idx, std::make_pair(31u, 34u));
   EXPECT_EQ(r4.getHighlights()[4].h_type, highlight_type::Identifier);
-  EXPECT_EQ(r4.getHighlights()[4].h_idx, std::make_pair(36, 40));
+  EXPECT_EQ(r4.getHighlights()[4].h_idx, std::make_pair(36u, 40u));
 
   Row r5 = doc.GetRows()[4];
   EXPECT_EQ(r5.getHighlights().size(), 0);
@@ -167,17 +167,17 @@ TEST(DocumentTest, DeleteFirstLine)
 {
   std::filesystem::path dirPath = std::filesystem::path(__FILE__).remove_filename();
   std::filesystem::path filePath = dirPath /= "DocumentTestFiles/cpp-sample.cpp";
-    
+
   Document doc(filePath);
   EXPECT_EQ(doc.GetRowsLength(), 5);
-  
+
   doc.Delete(-1, 3);
   EXPECT_EQ(doc.GetRowsLength(), 4);
 
   Row r1 = doc.GetRows()[0];
   EXPECT_EQ(r1.getHighlights().size(), 1);
   EXPECT_EQ(r1.getHighlights()[0].h_type, highlight_type::String);
-  EXPECT_EQ(r1.getHighlights()[0].h_idx, std::make_pair(9, 19));
+  EXPECT_EQ(r1.getHighlights()[0].h_idx, std::make_pair(9u, 19u));
 
   Row r2 = doc.GetRows()[1];
   EXPECT_EQ(r2.getHighlights().size(), 0);
@@ -185,19 +185,19 @@ TEST(DocumentTest, DeleteFirstLine)
   Row r3 = doc.GetRows()[2];
   EXPECT_EQ(r3.getHighlights().size(), 7);
   EXPECT_EQ(r3.getHighlights()[0].h_type, highlight_type::Keyword);
-  EXPECT_EQ(r3.getHighlights()[0].h_idx, std::make_pair(0, 3));
+  EXPECT_EQ(r3.getHighlights()[0].h_idx, std::make_pair(0u, 3u));
   EXPECT_EQ(r3.getHighlights()[1].h_type, highlight_type::Identifier);
-  EXPECT_EQ(r3.getHighlights()[1].h_idx, std::make_pair(4, 8));
+  EXPECT_EQ(r3.getHighlights()[1].h_idx, std::make_pair(4u, 8u));
   EXPECT_EQ(r3.getHighlights()[2].h_type, highlight_type::Keyword);
-  EXPECT_EQ(r3.getHighlights()[2].h_idx, std::make_pair(13, 16));
+  EXPECT_EQ(r3.getHighlights()[2].h_idx, std::make_pair(13u, 16u));
   EXPECT_EQ(r3.getHighlights()[3].h_type, highlight_type::Identifier);
-  EXPECT_EQ(r3.getHighlights()[3].h_idx, std::make_pair(18, 22));
+  EXPECT_EQ(r3.getHighlights()[3].h_idx, std::make_pair(18u, 22u));
   EXPECT_EQ(r3.getHighlights()[4].h_type, highlight_type::String);
-  EXPECT_EQ(r3.getHighlights()[4].h_idx, std::make_pair(26, 39));
+  EXPECT_EQ(r3.getHighlights()[4].h_idx, std::make_pair(26u, 39u));
   EXPECT_EQ(r3.getHighlights()[5].h_type, highlight_type::Keyword);
-  EXPECT_EQ(r3.getHighlights()[5].h_idx, std::make_pair(43, 46));
+  EXPECT_EQ(r3.getHighlights()[5].h_idx, std::make_pair(43u, 46u));
   EXPECT_EQ(r3.getHighlights()[6].h_type, highlight_type::Identifier);
-  EXPECT_EQ(r3.getHighlights()[6].h_idx, std::make_pair(48, 52));
+  EXPECT_EQ(r3.getHighlights()[6].h_idx, std::make_pair(48u, 52u));
 
   Row r4 = doc.GetRows()[3];
   EXPECT_EQ(r4.getHighlights().size(), 0);
@@ -207,17 +207,17 @@ TEST(DocumentTest, ReturnKey)
 {
   std::filesystem::path dirPath = std::filesystem::path(__FILE__).remove_filename();
   std::filesystem::path filePath = dirPath /= "DocumentTestFiles/multi-line.cpp";
-    
+
   Document doc(filePath);
   EXPECT_EQ(doc.GetRowsLength(), 6);
-  
+
   doc.ReturnKey(0, 4);
   EXPECT_EQ(doc.GetRowsLength(), 7);
 
   Row r1 = doc.GetRows()[0];
   EXPECT_EQ(r1.getHighlights().size(), 1);
   EXPECT_EQ(r1.getHighlights()[0].h_type, highlight_type::String);
-  EXPECT_EQ(r1.getHighlights()[0].h_idx, std::make_pair(9, 19));
+  EXPECT_EQ(r1.getHighlights()[0].h_idx, std::make_pair(9u, 19u));
 
   Row r2 = doc.GetRows()[1];
   EXPECT_EQ(r2.getHighlights().size(), 0);
@@ -225,23 +225,23 @@ TEST(DocumentTest, ReturnKey)
   Row r3 = doc.GetRows()[2];
   EXPECT_EQ(r3.getHighlights().size(), 2);
   EXPECT_EQ(r3.getHighlights()[0].h_type, highlight_type::Keyword);
-  EXPECT_EQ(r3.getHighlights()[0].h_idx, std::make_pair(0, 3));
+  EXPECT_EQ(r3.getHighlights()[0].h_idx, std::make_pair(0u, 3u));
   EXPECT_EQ(r3.getHighlights()[1].h_type, highlight_type::Identifier);
-  EXPECT_EQ(r3.getHighlights()[1].h_idx, std::make_pair(4, 8));
+  EXPECT_EQ(r3.getHighlights()[1].h_idx, std::make_pair(4u, 8u));
 
   Row r4 = doc.GetRows()[3];
   EXPECT_EQ(r4.getHighlights().size(), 5);
   EXPECT_EQ(r4.getHighlights()[0].h_type, highlight_type::Keyword);
-  EXPECT_EQ(r4.getHighlights()[0].h_idx, std::make_pair(2, 5));
+  EXPECT_EQ(r4.getHighlights()[0].h_idx, std::make_pair(2u, 5u));
   EXPECT_EQ(r4.getHighlights()[1].h_type, highlight_type::Identifier);
-  EXPECT_EQ(r4.getHighlights()[1].h_idx, std::make_pair(7, 11));
+  EXPECT_EQ(r4.getHighlights()[1].h_idx, std::make_pair(7u, 11u));
   EXPECT_EQ(r4.getHighlights()[2].h_type, highlight_type::String);
-  EXPECT_EQ(r4.getHighlights()[2].h_idx, std::make_pair(15, 28));
+  EXPECT_EQ(r4.getHighlights()[2].h_idx, std::make_pair(15u, 28u));
   EXPECT_EQ(r4.getHighlights()[3].h_type, highlight_type::Keyword);
-  EXPECT_EQ(r4.getHighlights()[3].h_idx, std::make_pair(32, 35));
+  EXPECT_EQ(r4.getHighlights()[3].h_idx, std::make_pair(32u, 35u));
   EXPECT_EQ(r4.getHighlights()[4].h_type, highlight_type::Identifier);
-  EXPECT_EQ(r4.getHighlights()[4].h_idx, std::make_pair(37, 41));
- 
+  EXPECT_EQ(r4.getHighlights()[4].h_idx, std::make_pair(37u, 41u));
+
   Row r5 = doc.GetRows()[4];
   EXPECT_EQ(r5.getText(), "");
   EXPECT_EQ(r5.getLen(), 0);
@@ -251,10 +251,10 @@ TEST(DocumentTest, ReturnKey)
   EXPECT_EQ(r6.getText(), "  int x = 10;");
   EXPECT_EQ(r6.getHighlights().size(), 3);
   EXPECT_EQ(r6.getHighlights()[0].h_type, highlight_type::Keyword);
-  EXPECT_EQ(r6.getHighlights()[0].h_idx, std::make_pair(2, 5));
+  EXPECT_EQ(r6.getHighlights()[0].h_idx, std::make_pair(2u, 5u));
   EXPECT_EQ(r6.getHighlights()[1].h_type, highlight_type::Identifier);
-  EXPECT_EQ(r6.getHighlights()[1].h_idx, std::make_pair(6, 7));
+  EXPECT_EQ(r6.getHighlights()[1].h_idx, std::make_pair(6u, 7u));
   EXPECT_EQ(r6.getHighlights()[2].h_type, highlight_type::Number);
-  EXPECT_EQ(r6.getHighlights()[2].h_idx, std::make_pair(10, 12));
+  EXPECT_EQ(r6.getHighlights()[2].h_idx, std::make_pair(10u, 12u));
 }
 


### PR DESCRIPTION
This PR fixes a build failure due to mismatched types (building with g++12).

Updated `EXPECT_EQ` comparisons to ensure type consistency between `std::pair<int, int>` and `std::pair<unsigned int, unsigned int>`. 

Integer literals in `std::make_pair` have been changed to use unsigned suffix (u) to match the expected type, preventing compiler errors related to mismatched `operator==`.

