### PR TITLE
Fix segfault when accessing row length in UpdateCursor

### DIFF
--- a/src/TextFileViewer.cpp
+++ b/src/TextFileViewer.cpp
@@ -167,10 +167,12 @@ void TextFileViewer::UpdateCursor() {
     auto& editor = Editor::GetInstance();
 
     // Bad structure but screw it... Bounds Check for line
-    int line_size = document.GetRows()[cursorY + viewportStart].getLen();
-    if (cursorY + viewportStart > document.GetRowsLength() - 1)
+    if (cursorY + viewportStart > document.GetRowsLength() - 1) {
         cursorY = std::min(document.GetRowsLength() - 1, GetBottomY());
-    if (cursorX > line_size) {
+    }
+
+    if (auto line_size = document.GetRows()[cursorY].getLen();
+        cursorX > line_size) {
         cursorX = line_size;
     }
 


### PR DESCRIPTION
The sum `cursorY + viewportStart` was used to access a row, without checking if that value was a valid index.

The row access has been moved after the check for the value of `cursorY + viewportStart`.

I wasn't exactly sure what the sum of `cursorY` and `viewportStart` represented, but I noticed that `cursorY` could end up set to `document.getRowsLength() - 1`, so accessing `cursorY + viewportStart` could still be unsafe.

I have changed this to just check `cursorY`. I'm happy to change this if it is not correct.

Related #5 